### PR TITLE
S390x support and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 perf-invok
+perf-invok-debug
+sandwich_return
+vector_add

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ CFLAGS ?= -O3 -Wall -Werror -pedantic -flto
 ifeq ($(shell cat /proc/cpuinfo | grep "uarch" | head -n 1 | cut -d" " -f 2),sifive,u54-mc)
 CFLAGS := ${CFLAGS} -DPERF_INVOK_PLATFORM_SIFIVE_FU540
 endif
+TEST_PROGRAMS = vector_add sandwich_return
 
-.PHONY: clean
+.PHONY: clean test
 
 all: perf-invok
 
@@ -12,10 +13,25 @@ perf-invok: src/main.c src/sample.c src/breakpoint.c
 	gcc ${CFLAGS} -o perf-invok src/main.c src/sample.c src/breakpoint.c
 
 debug: src/main.c src/sample.c src/breakpoint.c src/debug.h
-	gcc ${CFLAGS} -DDEBUG_MODE -o perf-invok-debug src/main.c src/sample.c src/breakpoint.c
+	gcc ${CFLAGS} -DDEBUG_MODE -g -o perf-invok-debug src/main.c src/sample.c src/breakpoint.c
+
+vector_add: test_programs/vector_add.c
+	gcc -O0 -no-pie -fno-pic -o $@ $^
+
+ifeq ($(shell uname -m),riscv64)
+sandwich_return: test_programs/sandwiched_return.c  test_programs/sandwiched_return_riscv.s
+	gcc -O0 -no-pie -fno-pic -o $@ $^
+else ifeq ($(shell uname -m),ppc64le)
+sandwich_return: test_programs/sandwiched_return.c  test_programs/sandwiched_return_ppc64.s
+	gcc -O0 -no-pie -fno-pic -o $@ $^
+endif
+
+test: $(TEST_PROGRAMS)
+	tests/test_vector_add.sh
+	tests/test_sandwich_return.sh
 
 install: perf-invok
 	cp perf-invok $(INSTALLDIR)/perf-invok
 
 clean:
-	rm -rf perf-invok
+	rm -rf perf-invok perf-invok-debug vector_add sandwich_return

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ endif
 
 .PHONY: clean
 
+all: perf-invok
+
 perf-invok: src/main.c src/sample.c src/breakpoint.c
 	gcc ${CFLAGS} -o perf-invok src/main.c src/sample.c src/breakpoint.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INSTALLDIR ?= /bin
-
+CFLAGS ?= -O3 -Wall -Werror -pedantic -flto
 ifeq ($(shell cat /proc/cpuinfo | grep "uarch" | head -n 1 | cut -d" " -f 2),sifive,u54-mc)
 CFLAGS := ${CFLAGS} -DPERF_INVOK_PLATFORM_SIFIVE_FU540
 endif

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ endif
 perf-invok: src/main.c src/sample.c src/breakpoint.c
 	gcc ${CFLAGS} -o perf-invok src/main.c src/sample.c src/breakpoint.c
 
+debug: src/main.c src/sample.c src/breakpoint.c src/debug.h
+	gcc ${CFLAGS} -DDEBUG_MODE -o perf-invok src/main.c src/sample.c src/breakpoint.c
+
 install: perf-invok
 	cp perf-invok $(INSTALLDIR)/perf-invok
 

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,18 @@ sandwich_return: test_programs/sandwiched_return.c  test_programs/sandwiched_ret
 else ifeq ($(shell uname -m),ppc64le)
 sandwich_return: test_programs/sandwiched_return.c  test_programs/sandwiched_return_ppc64.s
 	gcc -O0 -no-pie -fno-pic -o $@ $^
+else ifeq ($(shell uname -m),s390x)
+sandwich_return: test_programs/sandwiched_return.c  test_programs/sandwiched_return_s390x.s
+	gcc -O0 -no-pie -fno-pic -o $@ $^
+else
+	$(error Architecture not supported)
 endif
 
-test: $(TEST_PROGRAMS)
-	tests/test_vector_add.sh
-	tests/test_sandwich_return.sh
+test: all $(TEST_PROGRAMS)
+	@echo Testing generic code...
+	@tests/test_vector_add.sh
+	@echo Testing sandwich return...
+	@tests/test_sandwich_return.sh
 
 install: perf-invok
 	cp perf-invok $(INSTALLDIR)/perf-invok

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ perf-invok: src/main.c src/sample.c src/breakpoint.c
 	gcc ${CFLAGS} -o perf-invok src/main.c src/sample.c src/breakpoint.c
 
 debug: src/main.c src/sample.c src/breakpoint.c src/debug.h
-	gcc ${CFLAGS} -DDEBUG_MODE -o perf-invok src/main.c src/sample.c src/breakpoint.c
+	gcc ${CFLAGS} -DDEBUG_MODE -o perf-invok-debug src/main.c src/sample.c src/breakpoint.c
 
 install: perf-invok
 	cp perf-invok $(INSTALLDIR)/perf-invok

--- a/src/breakpoint.c
+++ b/src/breakpoint.c
@@ -11,12 +11,12 @@ void setBreakpoint(unsigned long pid, unsigned long long address,
     breakpoint->address = address;
     breakpoint->originalData = ptrace(PTRACE_PEEKDATA, pid, address, 0);
 
-    debug_print("setBreakpoint 0x%016X to 0x%08X (orig 0x%08X)\n", address, 0, breakpoint->originalData);
+    debug_print("setBreakpoint 0x%016llX to 0x%08X (orig 0x%08llX)\n", address, 0, breakpoint->originalData);
     ptrace(PTRACE_POKEDATA, pid, address, 0);
 }
 
 void resetBreakpoint(unsigned long pid, Breakpoint *breakpoint) {
-    debug_print("resetBreakpoint 0x%016X to 0x%08X\n", breakpoint->address, breakpoint->originalData);
+    debug_print("resetBreakpoint 0x%016llX to 0x%08llX\n", breakpoint->address, breakpoint->originalData);
     ptrace(PTRACE_POKEDATA, pid, breakpoint->address, breakpoint->originalData);
 }
 
@@ -27,12 +27,12 @@ void displace_pc(long pid, long displ) {
     iov.iov_len = sizeof(buf);
     iov.iov_base = buf;
 
-    long ret = ptrace(PTRACE_GETREGSET, pid, NT_PRSTATUS, &iov);
+    ptrace(PTRACE_GETREGSET, pid, NT_PRSTATUS, &iov);
     long pc = buf[1];
 
-	debug_print("displace_pc from 0x%016X to 0x%016X\n", pc, pc + displ);
+	debug_print("displace_pc from 0x%016lX to 0x%016lX\n", pc, pc + displ);
 
     buf[1] = pc + displ;
-    ret = ptrace(PTRACE_SETREGSET, pid, NT_PRSTATUS, &iov);
+    ptrace(PTRACE_SETREGSET, pid, NT_PRSTATUS, &iov);
 }
 #endif

--- a/src/breakpoint.c
+++ b/src/breakpoint.c
@@ -1,3 +1,4 @@
+#include "debug.h"
 #include "breakpoint.h"
 #include <sys/ptrace.h>
 
@@ -8,10 +9,12 @@ void setBreakpoint(unsigned long pid, unsigned long long address,
                    Breakpoint *breakpoint) {
     breakpoint->address = address;
     breakpoint->originalData = ptrace(PTRACE_PEEKDATA, pid, address, 0);
-    unsigned long long modifiedData = ((breakpoint->originalData & ~0xffff) | RV_INSTR_CEBREAK);
-    ptrace(PTRACE_POKEDATA, pid, address, modifiedData);
+
+    debug_print("setBreakpoint 0x%016X to 0x%08X (orig 0x%08X)\n", address, 0, breakpoint->originalData);
+    ptrace(PTRACE_POKEDATA, pid, address, 0);
 }
 
 void resetBreakpoint(unsigned long pid, Breakpoint *breakpoint) {
+    debug_print("resetBreakpoint 0x%016X to 0x%08X\n", breakpoint->address, breakpoint->originalData);
     ptrace(PTRACE_POKEDATA, pid, breakpoint->address, breakpoint->originalData);
 }

--- a/src/breakpoint.c
+++ b/src/breakpoint.c
@@ -13,10 +13,9 @@ void setBreakpoint(unsigned long pid, unsigned long long address,
                    Breakpoint *breakpoint) {
     breakpoint->address = address;
     errno = 0;
+    debug_print("setBreakpoint 0x%016llX to 0x%08X (orig 0x%08llX)\n", address, 0, breakpoint->originalData);
     breakpoint->originalData = ptrace(PTRACE_PEEKDATA, pid, address, 0);
     if (errno != 0) { perror("ERROR while setting breakpoint (read)"); exit(EXIT_FAILURE);};
-
-    debug_print("setBreakpoint 0x%016llX to 0x%08X (orig 0x%08llX)\n", address, 0, breakpoint->originalData);
     long ret = ptrace(PTRACE_POKEDATA, pid, address, 0);
     if (ret != 0) { perror("ERROR while setting breakpoint (write)"); exit(EXIT_FAILURE);};
 }

--- a/src/breakpoint.h
+++ b/src/breakpoint.h
@@ -6,3 +6,8 @@ typedef struct {
 void setBreakpoint(unsigned long pid, unsigned long long address,
                    Breakpoint *breakpoint);
 void resetBreakpoint(unsigned long pid, Breakpoint *breakpoint);
+
+#if defined(__s390x__)
+#define NT_PRSTATUS 1
+void displace_pc(long pid, long displ);
+#endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,9 @@
+#ifdef DEBUG_MODE
+#define DEBUG 1
+#else
+#define DEBUG 0
+#endif
+
+#define debug_print(fmt, ...) \
+	do { if (DEBUG) fprintf(stderr, "DEBUG:%s:%d:%s(): " fmt, __FILE__, \
+    __LINE__, __func__, __VA_ARGS__); } while (0)

--- a/src/debug.h
+++ b/src/debug.h
@@ -6,4 +6,4 @@
 
 #define debug_print(fmt, ...) \
 	do { if (DEBUG) fprintf(stderr, "DEBUG:%s:%d:%s(): " fmt, __FILE__, \
-    __LINE__, __func__, __VA_ARGS__); } while (0)
+    __LINE__, __func__,##__VA_ARGS__); } while (0)

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
 #include "debug.h"
 
 #define MAX_SAMPLES 8192
-#define MAX_BREAKPOINTS 128
+#define MAX_BREAKPOINTS 256
 
 int pid;
 Sample samples[MAX_SAMPLES];

--- a/src/main.c
+++ b/src/main.c
@@ -61,6 +61,14 @@ int perInvocationPerformance(unsigned long long addrStart,
         beginSample(&samples[sampleCount - flushedSampleCount]);
         sampleInProgress = 1;
 
+        #if defined(__s390x__)
+        if (WIFSTOPPED(status)) {
+            // Z architecture advances 2 bytes the PC on SIGILL
+            if (WSTOPSIG(status) == SIGILL) {
+                displace_pc(pid, -2);
+            }
+        }
+        #endif
         ptrace(PTRACE_CONT, pid, 0, 0);
         waitpid(pid, &status, 0);
         if (WIFSTOPPED(status)) {
@@ -82,6 +90,14 @@ int perInvocationPerformance(unsigned long long addrStart,
 
         resetBreakpoint(pid, &bp);
         setBreakpoint(pid, addrStart, &bp);
+        #if defined(__s390x__)
+        if (WIFSTOPPED(status)) {
+            // Z architecture advances 2 bytes the PC on SIGILL
+            if (WSTOPSIG(status) == SIGILL) {
+                displace_pc(pid, -2);
+            }
+        }
+        #endif
         ptrace(PTRACE_CONT, pid, 0, 0);
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -111,7 +111,15 @@ int perInvocationPerformance(unsigned long long * addrStart,
         ret = waitpid(pid, &status, 0);
         if (ret == -1) { perror("ERROR during waiting"); exit(EXIT_FAILURE);};
         if (WIFSTOPPED(status)) {
-            debug_print("%s\n", strsignal(WSTOPSIG(status)));
+            debug_print("Process stopped: %s\n", strsignal(WSTOPSIG(status)));
+        }
+        if (WIFEXITED(status)) {
+            debug_print("Process exit code: %d\n", WEXITSTATUS(status));
+            return WEXITSTATUS(status);
+        }
+        if (WIFSIGNALED(status)) {
+            debug_print("Process signaled: %s\n", strsignal(WTERMSIG(status)));
+            exit(EXIT_FAILURE);
         }
         sampleInProgress = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -120,9 +120,17 @@ int globalPerformance(unsigned int timeout) {
     beginSample(&samples[0]);
     sampleInProgress = 1;
 
-    ptrace(PTRACE_CONT, pid, 0, 0);
-    unsigned ret = alarm(timeout);
-    if (ret != 0) { perror("ERROR while setting timeout"); exit(EXIT_FAILURE);};
+    int ret =  ptrace(PTRACE_CONT, pid, 0, 0);
+    if (ret != 0) { perror("ERROR while setting trace"); exit(EXIT_FAILURE);};
+
+    if (timeout > 0 ) {
+        fprintf(stderr, "Timeout set to %d seconds\n", timeout);
+        ret = alarm(timeout);
+        if (ret != 0) { perror("ERROR while setting timeout"); exit(EXIT_FAILURE);};
+    } else {
+        fprintf(stderr, "No timeout set. Waiting process to finish\n");
+    }
+
     ret = waitpid(pid, &status, 0);
     if (ret == -1) { perror("ERROR while waiting"); exit(EXIT_FAILURE);};
 
@@ -233,7 +241,7 @@ int main(int argc, char **argv) {
         configureEvents(pid);
 
         if (addrStart > 0 && addrEnd > 0) {
-            fprintf(stderr, "Measuring performance counters from 0x%llx to 0x%llx (max. samples: %u).\n", addrStart, addrEnd, maxSamples);
+            fprintf(stderr, "Measuring performance counters from 0x%llx to 0x%llx (max. samples: %u)\n", addrStart, addrEnd, maxSamples);
             status = perInvocationPerformance(addrStart, addrEnd, maxSamples, outputFile);
         } else {
             fprintf(stderr, "Measuring performance counters from global execution\n");

--- a/src/main.c
+++ b/src/main.c
@@ -188,9 +188,9 @@ int main(int argc, char **argv) {
         }
     }
 
-    printf("Executing ");
-    for (int i = programStart; i < argc; i++) printf("%s ", argv[i]);
-    printf("\n");
+    fprintf(stderr, "Executing ");
+    for (int i = programStart; i < argc; i++) fprintf(stderr, "%s ", argv[i]);
+    fprintf(stderr, "\n");
 
     pid = fork();
 
@@ -233,10 +233,10 @@ int main(int argc, char **argv) {
         configureEvents(pid);
 
         if (addrStart > 0 && addrEnd > 0) {
-            printf("Measuring performance counters from 0x%llx to 0x%llx (max. samples: %u).\n", addrStart, addrEnd, maxSamples);
+            fprintf(stderr, "Measuring performance counters from 0x%llx to 0x%llx (max. samples: %u).\n", addrStart, addrEnd, maxSamples);
             status = perInvocationPerformance(addrStart, addrEnd, maxSamples, outputFile);
         } else {
-            printf("Measuring performance counters from global execution\n");
+            fprintf(stderr, "Measuring performance counters from global execution\n");
             status = globalPerformance(timeout);
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -81,7 +81,7 @@ int perInvocationPerformance(unsigned long long addrStart,
     return 0;
 }
 
-void globalPerformance(unsigned int timeout) {
+int globalPerformance(unsigned int timeout) {
     int status;
     beginSample(&samples[0]);
     sampleInProgress = 1;
@@ -93,6 +93,8 @@ void globalPerformance(unsigned int timeout) {
     sampleInProgress = 0;
     endSample(&samples[0]);
     sampleCount++;
+
+    return status;
 }
 
 int main(int argc, char **argv) {
@@ -191,7 +193,7 @@ int main(int argc, char **argv) {
             status = perInvocationPerformance(addrStart, addrEnd, maxSamples, outputFile);
         } else {
             printf("Measuring performance counters from global execution\n");
-            globalPerformance(timeout);
+            status = globalPerformance(timeout);
         }
 
         printSamples(outputFile, sampleCount - flushedSampleCount, samples,

--- a/src/sample.c
+++ b/src/sample.c
@@ -188,7 +188,7 @@ void endSample(Sample *sample) {
 
     char buf[4096];
     struct read_format *rf = (struct read_format *) buf;
-    read(fdCycles, buf, sizeof(buf));
+    if (read(fdCycles, buf, sizeof(buf)) == 0) { perror("ERROR while reading perf counters"); exit(EXIT_FAILURE); };
     for (unsigned int i = 0; i < rf->nr; i++) {
         unsigned long long id = rf->values[i].id;
         unsigned long long value = rf->values[i].value;

--- a/src/sample.c
+++ b/src/sample.c
@@ -60,20 +60,20 @@ void configureEvents(pid_t pid) {
     attributes.exclude_hv = 1;
     attributes.read_format = PERF_FORMAT_GROUP | PERF_FORMAT_ID;
 
-    debug_print("Configuring PERF_COUNT_HW_CPU_CYCLES\n", 0);
+    debug_print("Configuring PERF_COUNT_HW_CPU_CYCLES\n");
     attributes.config = PERF_COUNT_HW_CPU_CYCLES;
     attributes.type = PERF_TYPE_HARDWARE;
     fdCycles = syscall(__NR_perf_event_open, &attributes, pid, -1, -1, 0);
     ioctl(fdCycles, PERF_EVENT_IOC_ID, &idCycles);
 
-    debug_print("Configuring PERF_COUNT_HW_INSTRUCTIONS\n", 0);
+    debug_print("Configuring PERF_COUNT_HW_INSTRUCTIONS\n");
     attributes.config = PERF_COUNT_HW_INSTRUCTIONS;
     attributes.type = PERF_TYPE_HARDWARE;
     fdInstructions =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdInstructions, PERF_EVENT_IOC_ID, &idInstructions);
 
-    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:ACCESS\n", 0);
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:ACCESS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_READ << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16);
@@ -82,7 +82,7 @@ void configureEvents(pid_t pid) {
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdMemoryLoads, PERF_EVENT_IOC_ID, &idMemoryLoads);
 
-    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:ACCESS\n", 0);
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:ACCESS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_WRITE << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16);
@@ -91,7 +91,7 @@ void configureEvents(pid_t pid) {
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdMemoryWrites, PERF_EVENT_IOC_ID, &idMemoryWrites);
 
-    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:MISS\n", 0);
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:MISS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_READ << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_MISS << 16);
@@ -100,7 +100,7 @@ void configureEvents(pid_t pid) {
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdMemoryReadMisses, PERF_EVENT_IOC_ID, &idMemoryReadMisses);
 
-    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:MISS\n", 0);
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:MISS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_WRITE << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_MISS << 16);
@@ -117,7 +117,7 @@ void configureEvents(pid_t pid) {
 
 void beginSample(Sample *sample) {
 
-    debug_print("Begin sample, reset counters\n", 0);
+    debug_print("Begin sample, reset counters\n");
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
     WRITE_CSR(mhpmcounter3, 0);
@@ -136,12 +136,12 @@ void beginSample(Sample *sample) {
     ioctl(fdCycles, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
 
 #endif
-    debug_print("Begin sample, reset counters done\n", 0);
+    debug_print("Begin sample, reset counters done\n");
 }
 
 void endSample(Sample *sample) {
 
-    debug_print("End sample, read counters\n", 0);
+    debug_print("End sample, read counters\n");
 
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
@@ -179,7 +179,7 @@ void endSample(Sample *sample) {
 
 #endif
 
-    debug_print("End sample, read counters done\n", 0);
+    debug_print("End sample, read counters done\n");
 
 }
 

--- a/src/sample.c
+++ b/src/sample.c
@@ -1,5 +1,7 @@
 #include "sample.h"
 #include "debug.h"
+#include "errno.h"
+#include <stdlib.h>
 
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
@@ -64,14 +66,18 @@ void configureEvents(pid_t pid) {
     attributes.config = PERF_COUNT_HW_CPU_CYCLES;
     attributes.type = PERF_TYPE_HARDWARE;
     fdCycles = syscall(__NR_perf_event_open, &attributes, pid, -1, -1, 0);
-    ioctl(fdCycles, PERF_EVENT_IOC_ID, &idCycles);
+    if (fdCycles == -1) { perror("ERROR while setting PERF_COUNT_HW_CPU_CYCLES"); exit(EXIT_FAILURE); };
+    int ret = ioctl(fdCycles, PERF_EVENT_IOC_ID, &idCycles);
+    if (ret == -1) { perror("ERROR while getting PERF_COUNT_HW_CPU_CYCLES event id"); exit(EXIT_FAILURE); };
 
     debug_print("Configuring PERF_COUNT_HW_INSTRUCTIONS\n");
     attributes.config = PERF_COUNT_HW_INSTRUCTIONS;
     attributes.type = PERF_TYPE_HARDWARE;
     fdInstructions =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
-    ioctl(fdInstructions, PERF_EVENT_IOC_ID, &idInstructions);
+    if (fdInstructions == -1) { perror("ERROR while setting PERF_COUNT_HW_INSTRUCTIONS"); exit(EXIT_FAILURE); };
+    ret = ioctl(fdInstructions, PERF_EVENT_IOC_ID, &idInstructions);
+    if (ret == -1) { perror("ERROR while getting PERF_COUNT_HW_INSTRUCTIONS event id"); exit(EXIT_FAILURE); };
 
     debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:ACCESS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
@@ -80,7 +86,12 @@ void configureEvents(pid_t pid) {
     attributes.type = PERF_TYPE_HW_CACHE;
     fdMemoryLoads =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
-    ioctl(fdMemoryLoads, PERF_EVENT_IOC_ID, &idMemoryLoads);
+    if (fdMemoryLoads == -1) {
+        perror("WARNING: Unable to set PERF_COUNT_HW_CACHE_L1D:READ:ACCESS");
+    } else {
+        ret = ioctl(fdMemoryLoads, PERF_EVENT_IOC_ID, &idMemoryLoads);
+        if (ret == -1) { perror("ERROR while getting PERF_COUNT_HW_CACHE_L1D:READ:ACCESS event id"); exit(EXIT_FAILURE); }
+    }
 
     debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:ACCESS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
@@ -89,7 +100,12 @@ void configureEvents(pid_t pid) {
     attributes.type = PERF_TYPE_HW_CACHE;
     fdMemoryWrites =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
-    ioctl(fdMemoryWrites, PERF_EVENT_IOC_ID, &idMemoryWrites);
+    if (fdMemoryWrites == -1) {
+        perror("WARNING: Unable to set PERF_COUNT_HW_CACHE_L1D:WRITE:ACCESS");
+    } else {
+        ret = ioctl(fdMemoryWrites, PERF_EVENT_IOC_ID, &idMemoryWrites);
+        if (ret == -1) { perror("ERROR while getting PERF_COUNT_HW_CACHE_L1D:WRITE:ACCESS event id"); exit(EXIT_FAILURE); }
+    }
 
     debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:MISS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
@@ -98,7 +114,12 @@ void configureEvents(pid_t pid) {
     attributes.type = PERF_TYPE_HW_CACHE;
     fdMemoryReadMisses =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
-    ioctl(fdMemoryReadMisses, PERF_EVENT_IOC_ID, &idMemoryReadMisses);
+    if (fdMemoryReadMisses == -1) {
+        perror("WARNING: Unable to set PERF_COUNT_HW_CACHE_L1D:READ:MISS");
+    } else {
+        ret = ioctl(fdMemoryReadMisses, PERF_EVENT_IOC_ID, &idMemoryReadMisses);
+        if (ret == -1) { perror("ERROR while getting PERF_COUNT_HW_CACHE_L1D:READ:MISS event id"); exit(EXIT_FAILURE); }
+    }
 
     debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:MISS\n");
     attributes.config = PERF_COUNT_HW_CACHE_L1D
@@ -107,7 +128,12 @@ void configureEvents(pid_t pid) {
     attributes.type = PERF_TYPE_HW_CACHE;
     fdMemoryWriteMisses =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
-    ioctl(fdMemoryWriteMisses, PERF_EVENT_IOC_ID, &idMemoryWriteMisses);
+    if (fdMemoryWriteMisses == -1) {
+        perror("WARNING: Unable to set PERF_COUNT_HW_CACHE_L1D:WRITE:MISS");
+    } else {
+        ret = ioctl(fdMemoryWriteMisses, PERF_EVENT_IOC_ID, &idMemoryWriteMisses);
+        if (ret == -1) { perror("ERROR while getting PERF_COUNT_HW_CACHE_L1D:WRITE:MISS event id"); exit(EXIT_FAILURE); }
+    }
 
 #endif
 

--- a/src/sample.c
+++ b/src/sample.c
@@ -1,4 +1,5 @@
 #include "sample.h"
+#include "debug.h"
 
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
@@ -39,9 +40,13 @@ struct timeval start;
 
 void configureEvents(pid_t pid) {
 
+    debug_print("Configuring events for process %d\n", pid);
+
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
+    debug_print("Configuring EVENT_MEM_INSTR_RETIRED");
     WRITE_CSR(mhpmevent3, EVENT_MEM_INSTR_RETIRED);
+    debug_print("Configuring EVENT_DATA_CACHE_MISS");
     WRITE_CSR(mhpmevent4, EVENT_DATA_CACHE_MISS);
 
 #else
@@ -55,17 +60,20 @@ void configureEvents(pid_t pid) {
     attributes.exclude_hv = 1;
     attributes.read_format = PERF_FORMAT_GROUP | PERF_FORMAT_ID;
 
+    debug_print("Configuring PERF_COUNT_HW_CPU_CYCLES\n", 0);
     attributes.config = PERF_COUNT_HW_CPU_CYCLES;
     attributes.type = PERF_TYPE_HARDWARE;
     fdCycles = syscall(__NR_perf_event_open, &attributes, pid, -1, -1, 0);
     ioctl(fdCycles, PERF_EVENT_IOC_ID, &idCycles);
 
+    debug_print("Configuring PERF_COUNT_HW_INSTRUCTIONS\n", 0);
     attributes.config = PERF_COUNT_HW_INSTRUCTIONS;
     attributes.type = PERF_TYPE_HARDWARE;
     fdInstructions =
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdInstructions, PERF_EVENT_IOC_ID, &idInstructions);
 
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:ACCESS\n", 0);
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_READ << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16);
@@ -74,6 +82,7 @@ void configureEvents(pid_t pid) {
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdMemoryLoads, PERF_EVENT_IOC_ID, &idMemoryLoads);
 
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:ACCESS\n", 0);
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_WRITE << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16);
@@ -82,6 +91,7 @@ void configureEvents(pid_t pid) {
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdMemoryWrites, PERF_EVENT_IOC_ID, &idMemoryWrites);
 
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:READ:MISS\n", 0);
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_READ << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_MISS << 16);
@@ -90,6 +100,7 @@ void configureEvents(pid_t pid) {
         syscall(__NR_perf_event_open, &attributes, pid, -1, fdCycles, 0);
     ioctl(fdMemoryReadMisses, PERF_EVENT_IOC_ID, &idMemoryReadMisses);
 
+    debug_print("Configuring PERF_COUNT_HW_CACHE_L1D:WRITE:MISS\n", 0);
     attributes.config = PERF_COUNT_HW_CACHE_L1D
                         | (PERF_COUNT_HW_CACHE_OP_WRITE << 8)
                         | (PERF_COUNT_HW_CACHE_RESULT_MISS << 16);
@@ -100,9 +111,13 @@ void configureEvents(pid_t pid) {
 
 #endif
 
+    debug_print("Configuring events for process %d done\n", pid);
+
 }
 
 void beginSample(Sample *sample) {
+
+    debug_print("Begin sample, reset counters\n", 0);
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
     WRITE_CSR(mhpmcounter3, 0);
@@ -121,9 +136,12 @@ void beginSample(Sample *sample) {
     ioctl(fdCycles, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
 
 #endif
+    debug_print("Begin sample, reset counters done\n", 0);
 }
 
 void endSample(Sample *sample) {
+
+    debug_print("End sample, read counters\n", 0);
 
 #ifdef PERF_INVOK_PLATFORM_SIFIVE_FU540
 
@@ -160,6 +178,8 @@ void endSample(Sample *sample) {
     }
 
 #endif
+
+    debug_print("End sample, read counters done\n", 0);
 
 }
 

--- a/test_programs/sandwiched_return.c
+++ b/test_programs/sandwiched_return.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+extern unsigned long long sandwich_return();
+
+int main() {
+    unsigned long long result = sandwich_return();
+    printf("%016llx\n", result);
+    return 0;
+}

--- a/test_programs/sandwiched_return_ppc64.s
+++ b/test_programs/sandwiched_return_ppc64.s
@@ -1,0 +1,14 @@
+.section .text
+.align 2
+.globl sandwich_return
+.type sandwich_return,@function
+sandwich_return:
+    b .L2
+.L1:
+    blr
+    .4byte 0xdeadbeef
+.L2:
+    lis 3,.L1@ha
+    la 3,.L1@l(3)
+    ld 3, 0(3)
+    b .L1

--- a/test_programs/sandwiched_return_riscv.s
+++ b/test_programs/sandwiched_return_riscv.s
@@ -1,0 +1,10 @@
+.global sandwich_return
+sandwich_return:
+    j .L2
+.L1:
+    ret
+    .word 0xdeadbeef
+.L2:
+    la a0, .L1
+    ld a0, 0(a0)
+    j .L1

--- a/test_programs/sandwiched_return_s390x.s
+++ b/test_programs/sandwiched_return_s390x.s
@@ -1,0 +1,14 @@
+.text
+	.align	8
+	.align	16
+.globl sandwich_return
+	.type	sandwich_return, @function
+sandwich_return:
+    j .L2
+.L1: 
+	br	%r14
+    .byte 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad
+.L2:
+    larl %r2, .L1
+    lg %r2, 0(%r2)
+    j .L1

--- a/test_programs/vector_add.c
+++ b/test_programs/vector_add.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+void add(unsigned int N, int *a, int *b, int *c) {
+    for (unsigned int i = 0; i < N; i++)
+       c[i] = a[i] + b[i];
+}
+
+void main() {
+    const unsigned int max_n = 100000000;
+    int *a = malloc(sizeof(int) * max_n);
+    int *b = malloc(sizeof(int) * max_n);
+    int *c = malloc(sizeof(int) * max_n);
+
+    for (unsigned int i = 0; i < 10; i++)
+        add(i % 2 ? max_n : max_n / 100, a, b, c);
+}

--- a/tests/test_sandwich_return.sh
+++ b/tests/test_sandwich_return.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/bash
+
+csv_file=$(mktemp)
+log_stdout_file=$(mktemp)
+log_stderr_file=$(mktemp)
+machine=$(uname -m)
+
+function cleanup {
+    rm $csv_file $log_stdout_file $log_stderr_file
+}
+
+if [ "$machine" == "riscv64" ]; then
+    marks_cmd=chop-marks-riscv
+    return_instr="8082"
+    return_instr_len=4
+elif [ "$machine" == "ppc64le" ]; then
+    marks_cmd=chop-marks-ppc64
+    return_instr="4e800020"
+    return_instr_len=8
+else
+    echo "Unsupported architecture: $machine"
+    cleanup
+    exit 1
+fi
+
+string_offset=$((8 - $return_instr_len))
+string_length=$((8 + $return_instr_len))
+
+function mkbreakpoint {
+    for i in $(seq 1 $1); do echo -n "0"; done
+}
+
+string_breakpoint=$(mkbreakpoint $return_instr_len)
+
+if ! hash $marks_cmd &> /dev/null; then
+    echo "ChopStiX marks command ($marks_cmd) not found"
+    cleanup
+    exit 1
+fi
+
+echo "Testing accurate breakpoint positioning by placing a breakpoint sandwiched in between function code. Only the return instruction should be \"occluded\" by the breakpoint. The instructions before and after should be O.K."
+
+./sandwich_return 1> $log_stdout_file
+if [ $? -ne 0 ]; then
+    echo "Couldn't execute test program"
+    echo "logs:"
+    cat $log_stdout_file
+    cleanup
+    exit 1
+fi
+
+echo "Binary contents of the test program are OK."
+
+output=$(cat $log_stdout_file)
+
+if [ "${output:$string_offset:$string_length}" != "deadbeef$return_instr" ]; then
+    # "deadbeef" is the hard-coded sentinel in the binary
+    # Because there is no breakpoint, the instruction appears in the binary dump
+    echo "Unexpected binary contents in the test program. Did something from the test bench break?"
+    echo "Expected: deadbeef$return_instr"
+    echo "Actual: ${output:$string_offset:$string_length}"
+    cleanup
+    exit 1
+fi
+
+timeout 5 ./perf-invok -o $csv_file $($marks_cmd ./sandwich_return sandwich_return) -- ./sandwich_return 2> $log_stderr_file 1> $log_stdout_file
+
+ret_val=$?
+if [ $ret_val -ne 0 ]; then
+    if [ $ret_val -eq 124 ]; then
+        echo "perf-invok timed out (5 seconds). This probably means it got stuck in an infinite loop."
+    else
+        echo "perf-invok returned an error exit code"
+    fi
+    echo "logs:"
+    cat $log_stderr_file
+    cleanup
+    exit 1
+fi
+
+echo "Return code OK."
+
+if [ ! -f "$csv_file" ]; then
+    echo "perf-invok didn't create an output file"
+    echo "logs:"
+    cat $log_stderr_file
+    cleanup
+    exit 1
+fi
+
+row_count=$(wc -l $csv_file | cut -d' ' -f 1)
+
+if [ $row_count -ne 2 ]; then
+    echo "Output file contains unexpected number of rows (Expected 2, got $row_count)"
+    echo "Logs:"
+    echo $log_stderr_file
+    cleanup
+    exit 1
+fi
+
+echo "Row count OK."
+
+output=$(cat $log_stdout_file)
+
+if [ "${output:$string_offset:$string_length}" != "deadbeef$string_breakpoint" ]; then
+    # Because this time the binary was run with a breakpoint in place, the
+    # return instruction isn't present anymore and instead we find a bunch of
+    # zeroes (the breakpoint). 0xdeadbeef should still be present. If it isn't,
+    # that means the program incorrectly sets breakpoints to the code further
+    # below the instruction where the breakpoint should actually be.
+    # NOTE: This test probably only works on little-endian architectures?
+
+    echo "The breakpoint encompases more than the targetted return instruction."
+    echo "This could cause unexpected problems when, within the same function,"
+    echo "there are instructions to be executed below the return instruction."
+    echo "Expected: deadbeef$string_breakpoint"
+    echo "Actual: ${output:$string_offset:$string_length}"
+    cleanup
+    exit 1
+fi
+
+echo "Breakpoint positioning OK."
+
+echo "Test passed."
+
+cleanup
+

--- a/tests/test_vector_add.sh
+++ b/tests/test_vector_add.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/bash
+
+csv_file=$(mktemp)
+log_file=$(mktemp)
+machine=$(uname -m)
+header="Cycles, Time Elapsed (us), Retired Instructions, Retired Memory Instructions, Data Cache Misses, Instructions Per Cycle, Miss Percentage"
+
+function cleanup {
+    rm $csv_file $log_file
+}
+
+if [ "$machine" == "riscv64" ]; then
+    marks_cmd=chop-marks-riscv
+elif [ "$machine" == "ppc64le" ]; then
+    marks_cmd=chop-marks-ppc64
+else
+    echo "Unsupported architecture: $machine"
+    cleanup
+    exit 1
+fi
+
+if ! hash $marks_cmd &> /dev/null; then
+    echo "ChopStiX marks command ($marks_cmd) not found"
+    cleanup
+    exit 1
+fi
+
+echo "Testing basic functionality using a function with two distinct alternate behaviours (this might take a while)..."
+
+./perf-invok -o $csv_file $($marks_cmd ./vector_add add) -- ./vector_add &> $log_file
+
+if [ $? -ne 0 ]; then
+    echo "perf-invok returned an error exit code"
+    echo "logs:"
+    cat $log_file
+    cleanup
+    exit 1
+fi
+
+echo "Return code OK."
+
+if [ ! -f "$csv_file" ]; then
+    echo "perf-invok didn't create an output file"
+    echo "logs:"
+    cat $log_file
+    cleanup
+    exit 1
+fi
+
+row_count=$(wc -l $csv_file | cut -d' ' -f 1)
+
+if [ $row_count -ne 11 ]; then
+    echo "Output file contains unexpected number of rows (Expected 11, got $row_count)"
+    echo "Logs:"
+    echo $logs
+    cleanup
+    exit 1
+fi
+
+echo "Row count OK."
+
+if [ "$(head -n 1 $csv_file)" != "$header" ]; then
+    echo "Output file has an incorrect header"
+    echo "Expected:"
+    echo $header
+    echo "Actual:"
+    echo $(head -n 1 $csv_file)
+    echo "Logs:"
+    echo $logs
+    cleanup
+    exit 1
+fi
+
+echo "Output file header OK."
+
+odd_invocation=$(tail -n 1 $csv_file | cut -d',' -f 3)
+even_invocation=$(tail -n 2 $csv_file | head -n 1 | cut -d',' -f 3)
+
+if (( ! $(echo "$even_invocation * 100 > $odd_invocation * 0.95 && $even_invocation * 100 < $odd_invocation * 1.05" | bc -l) )); then
+    echo "Expected odd invocations to have approximately 100 times (+- 5%) instructions than even invocations"
+    echo "Instructions in odd invocations: $odd_invocation"
+    echo "Instructions in even invocations: $even_invocation"
+    echo "Logs:"
+    echo $logs
+    cleanup
+    exit 1
+fi
+
+echo "Retired instruction counts OK."
+
+echo "Test passed."
+
+cleanup

--- a/tests/test_vector_add.sh
+++ b/tests/test_vector_add.sh
@@ -13,6 +13,8 @@ if [ "$machine" == "riscv64" ]; then
     marks_cmd=chop-marks-riscv
 elif [ "$machine" == "ppc64le" ]; then
     marks_cmd=chop-marks-ppc64
+elif [ "$machine" == "s390x" ]; then
+    marks_cmd=chop-marks-sysz
 else
     echo "Unsupported architecture: $machine"
     cleanup


### PR DESCRIPTION
The following changes have been implemented during the port to s390x:
- Add s390x (IBM Z) support: On that platform the PC needs to be restored after a SIGILL signal.
- Check return code on all library/system calls: Ensure robustness and future correctness. 
- Enabled pedantic compilation flags and implemented corresponding fixes: Ensure robustness and future correctness.
- Add debug facility and messages: added `debug_print` function, and used it throughout the code. The debug mode is enabled with the new `make debug` Makefile target.
- Do not mangle application std. output: avoid future problems if wrapper scripts check for std. output miss matches. In the future we might need to add an option to silent all the `perf-invok` output, including the std.err output. 
- Return exit status of the profiled process: avoid future problems if validation wrapper scripts check for exit status of the profiled process.
- Add support for multiple `-end` points.  
- Add default `all` target in Makefile: minor fix.
- Set timeout only when needed and include informational message: usability.
- Removed RISCV specific code when setting breakpoint. Instead of using the **BREAK** instruction, now a zero word is written to set the breakpoint. I hope this is generic in all architectures, otherwise we might need to define a different breakpoint value for each target architecture.  

Signed-off-by: Ramon Bertran Monfort <rbertra@us.ibm.com>